### PR TITLE
Issue/16: Fix validation for zip codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Ability to specify distance as a parameter to the API functions
 ### Changed
 - Omit the distance from the webservice payload if not provided
+### Fixed
+- Treat 5-digit zip codes beginning with 0 as valid
 
 ## Release 0.1.2 [2020-06-12]
 ### Fixed

--- a/airnowpy/api.py
+++ b/airnowpy/api.py
@@ -1,5 +1,6 @@
 import json
 import pytz
+import re
 import requests
 
 from datetime import date, datetime, time
@@ -73,14 +74,14 @@ class API(object):
         return self._convertResponseToObservation(response)
 
     def getCurrentObservationByZipCode(self,
-            zipCode: int,
+            zipCode: str,
             distanceMiles: int = 0) -> List[Observation]:
         """
         Retrieve the current air quality observation closest to the given
         location provided as a Zip Code.
 
         Parameters:
-            zipCode (int): Zip Code as a number.
+            zipCode (int): Zip Code as a string.
             [distanceMiles] (int): Distance in miles.
 
         Returns:
@@ -91,9 +92,11 @@ class API(object):
             https://docs.airnowapi.org/CurrentObservationsByZip/docs
         """
         # Validate Arguments
-        if (zipCode < 10000 or 99999 < zipCode):
+        zipCodeRegExp = re.compile(r'^\d{5}$')
+        zipCodeMatch = zipCodeRegExp.match(zipCode)
+        if (zipCodeMatch is None):
             raise ValueError(
-                "Zip Code must be between 10000 and 99999: " + str(zipCode))
+                "Zip Code must be a 5-digit string: " + zipCode)
         if (distanceMiles < 0):
             raise ValueError(
                 "Distance must be a positive integer: " + str(distanceMiles))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,13 +83,13 @@ class APITest(TestCase):
             self._assertObservations(observations)
 
     def test_getCurrentObservationByZipCode_badZipCodeLower(self):
-        self._checkBadZipCode(9999)
+        self._checkBadZipCode("9999")
 
     def test_getCurrentObservationByZipCode_badZipCodeUpper(self):
-        self._checkBadZipCode(100000)
+        self._checkBadZipCode("100000")
 
-    def _checkBadZipCode(self, zipCode: int) -> None:
-        expectedMsg = "Zip Code must be between 10000 and 99999: " + str(zipCode)
+    def _checkBadZipCode(self, zipCode: str) -> None:
+        expectedMsg = "Zip Code must be a 5-digit string: " + zipCode
         with self.assertRaises(ValueError) as context:
             self.api.getCurrentObservationByZipCode(zipCode)
             ex = context.exception
@@ -102,8 +102,12 @@ class APITest(TestCase):
     def test_getCurrentObservationByZipCode_withDistance(self):
         self.executeGetCurrentObservationByZipCodeTest(True)
 
-    def executeGetCurrentObservationByZipCodeTest(self, useDistance: bool) -> None:
-        zipCode = 98185
+    def test_getCurrentObservationByZipCode_ZeroZipCode(self):
+        self.executeGetCurrentObservationByZipCodeTest(True, "01234")
+
+    def executeGetCurrentObservationByZipCodeTest(self,
+            useDistance: bool,
+            zipCode: str = "98185") -> None:
         distance = 10
 
         expected_url = "http://" + API._HOST + API._ENDPOINT_OBSERVATION_BY_ZIPCODE


### PR DESCRIPTION
This PR addressed #16 by fixing the validation of the zip code parameter to allow inputs that begin with a 0.